### PR TITLE
Atualziação 2.7.1

### DIFF
--- a/src/biss-solutions/src/front/biss-solutions-site/src/app/components/carousel/carousel.html
+++ b/src/biss-solutions/src/front/biss-solutions-site/src/app/components/carousel/carousel.html
@@ -1,7 +1,7 @@
 <div class="carousel">
   <div class="carousel-container">
     <div class="carousel-slides" [style.transform]="'translateX(' + (-currentSlide * 100) + '%)'">
-      @for (slide of slides; track slide.id; let i = $index) {
+      @for (slide of enabledSlides; track slide.id; let i = $index) {
         <div
           class="carousel-slide"
           [style.background-image]="'url(' + getOptimizedImageUrl(slide.image) + ')'"
@@ -23,7 +23,7 @@
 
     <!-- Indicadores -->
     <div class="carousel-indicators">
-      @for (slide of slides; track slide.id; let i = $index) {
+      @for (slide of enabledSlides; track slide.id; let i = $index) {
         <button
           class="indicator"
           [class.active]="i === currentSlide"

--- a/src/biss-solutions/src/front/biss-solutions-site/src/app/components/carousel/carousel.ts
+++ b/src/biss-solutions/src/front/biss-solutions-site/src/app/components/carousel/carousel.ts
@@ -11,6 +11,8 @@ interface CarouselSlide {
   buttonText: string;
   buttonLink: string;
   overlayColor: string;
+  /** Quando false, o slide não é exibido (desabilitado, mantido no código). */
+  enabled?: boolean;
 }
 
 @Component({
@@ -33,7 +35,8 @@ export class Carousel implements OnInit, OnDestroy {
       subtitle: '🎁 Landing Page Profissional + Hospedagem 1 ano + 5 e-mails personalizados. Tudo que você precisa para começar a vender online!',
       buttonText: 'Aproveite Agora',
       buttonLink: '/services/pacote-completo',
-      overlayColor: 'rgba(220, 38, 127, 0.5)'
+      overlayColor: 'rgba(220, 38, 127, 0.5)',
+      enabled: false
     },
     {
       id: 1,
@@ -73,6 +76,11 @@ export class Carousel implements OnInit, OnDestroy {
     }
   ];
 
+  /** Slides exibidos no carrossel (exclui os com enabled: false). */
+  get enabledSlides(): CarouselSlide[] {
+    return this.slides.filter(s => s.enabled !== false);
+  }
+
   ngOnInit() {
     this.startAutoSlide();
     this.preloadCarouselImages();
@@ -82,9 +90,9 @@ export class Carousel implements OnInit, OnDestroy {
    * Preload das imagens do carrossel para melhor performance
    */
   private preloadCarouselImages(): void {
-    this.slides.forEach((slide, index) => {
-      // Preload apenas a primeira imagem (atual) e a próxima
-      if (index === this.currentSlide || index === (this.currentSlide + 1) % this.slides.length) {
+    const enabled = this.enabledSlides;
+    enabled.forEach((slide, index) => {
+      if (index === this.currentSlide || index === (this.currentSlide + 1) % enabled.length) {
         const img = new Image();
         img.src = slide.image;
       }
@@ -110,13 +118,15 @@ export class Carousel implements OnInit, OnDestroy {
   }
 
   nextSlide() {
-    this.currentSlide = (this.currentSlide + 1) % this.slides.length;
+    const n = this.enabledSlides.length;
+    this.currentSlide = (this.currentSlide + 1) % n;
     this.stopAutoSlide();
     this.startAutoSlide();
   }
 
   previousSlide() {
-    this.currentSlide = this.currentSlide === 0 ? this.slides.length - 1 : this.currentSlide - 1;
+    const n = this.enabledSlides.length;
+    this.currentSlide = this.currentSlide === 0 ? n - 1 : this.currentSlide - 1;
     this.stopAutoSlide();
     this.startAutoSlide();
   }

--- a/src/biss-solutions/src/front/biss-solutions-site/src/app/components/footer/footer.html
+++ b/src/biss-solutions/src/front/biss-solutions-site/src/app/components/footer/footer.html
@@ -20,7 +20,7 @@
 
         <div class="footer-info">
           <i class="ri-mail-line icon-sm"></i>
-          <span>contact@biss.com.br</span>
+          <span>contato@biss.com.br</span>
         </div>
 
         <div class="footer-info">

--- a/src/biss-solutions/src/front/biss-solutions-site/src/app/components/footer/footer.html
+++ b/src/biss-solutions/src/front/biss-solutions-site/src/app/components/footer/footer.html
@@ -65,7 +65,7 @@
 
     <!-- Seção de Direitos Autorais -->
     <div class="footer-copyright">
-      <p>© 2025 Biss Solutions. Todos os direitos reservados.</p>
+      <p>© 2026 Biss Solutions. Todos os direitos reservados.</p>
       <p class="version-info">Versão {{ version }}</p>
     </div>
   </div>

--- a/src/biss-solutions/src/front/biss-solutions-site/src/app/pages/about/about.html
+++ b/src/biss-solutions/src/front/biss-solutions-site/src/app/pages/about/about.html
@@ -160,7 +160,7 @@
           <div class="timeline-marker">1</div>
           <div class="timeline-content">
             <h3>API Admin</h3>
-            <p>Desenvolvimento de API administrativa para gerenciamento de conteúdo</p>
+            <p>Em desenvolvimento</p>
           </div>
         </div>
         <div class="timeline-item">
@@ -196,6 +196,20 @@
           <div class="timeline-content">
             <h3>Social Integration</h3>
             <p>Integração completa com redes sociais</p>
+          </div>
+        </div>
+        <div class="timeline-item">
+          <div class="timeline-marker">7</div>
+          <div class="timeline-content">
+            <h3>Email Service</h3>
+            <p>Serviço de envio e gestão de e-mails</p>
+          </div>
+        </div>
+        <div class="timeline-item">
+          <div class="timeline-marker">8</div>
+          <div class="timeline-content">
+            <h3>Loja Rápida</h3>
+            <p>Plataforma de e-commerce simplificada</p>
           </div>
         </div>
       </div>

--- a/src/biss-solutions/src/front/biss-solutions-site/src/app/services/version.service.ts
+++ b/src/biss-solutions/src/front/biss-solutions-site/src/app/services/version.service.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@angular/core';
   providedIn: 'root'
 })
 export class VersionService {
-  readonly version = '2.6.2';
+  readonly version = '2.7.0';
   readonly buildDate = new Date().toISOString();
 
   getVersion(): string {

--- a/src/biss-solutions/src/front/biss-solutions-site/src/app/services/version.service.ts
+++ b/src/biss-solutions/src/front/biss-solutions-site/src/app/services/version.service.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@angular/core';
   providedIn: 'root'
 })
 export class VersionService {
-  readonly version = '2.7.0';
+  readonly version = '2.7.1';
   readonly buildDate = new Date().toISOString();
 
   getVersion(): string {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/content updates with a small carousel filtering change; main potential issue is edge cases if all slides are disabled (modulo by zero).
> 
> **Overview**
> Bumps the site version to `2.7.1` and updates footer copy (contact email and copyright year).
> 
> Adjusts the carousel to support disabling slides via an optional `enabled` flag, rendering/navigating/preloading only `enabledSlides` (and disables the first promotional slide by default).
> 
> Updates the About page roadmap content (marks *API Admin* as “Em desenvolvimento” and adds new roadmap items for *Email Service* and *Loja Rápida*).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d4401d64d1369ac5370bdf8d23eb219be1ea108. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->